### PR TITLE
Added LaunchScreen.storyboard to get rid of black bars on iOS9/Xcode7.

### DIFF
--- a/client/KeyGrip.xcodeproj/project.pbxproj
+++ b/client/KeyGrip.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4027B776186205EC00168444 /* RCWHealthMeter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4027B775186205EC00168444 /* RCWHealthMeter.m */; };
+		9E4A221B1BC5F2CB00AC5C3B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E4A221A1BC5F2CB00AC5C3B /* LaunchScreen.storyboard */; settings = {ASSET_TAGS = (); }; };
 		AB006109183863EE00667A46 /* RCWGentleErrorNotificationView.m in Sources */ = {isa = PBXBuildFile; fileRef = AB006108183863EE00667A46 /* RCWGentleErrorNotificationView.m */; };
 		AB021FEB183B1F4F00DC2725 /* RCWGentleErrorNotificationView-bg.png in Resources */ = {isa = PBXBuildFile; fileRef = AB021FEA183B1F4F00DC2725 /* RCWGentleErrorNotificationView-bg.png */; };
 		AB14CA09180E08A4000FCF87 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB14CA08180E08A4000FCF87 /* Foundation.framework */; };
@@ -55,6 +56,7 @@
 /* Begin PBXFileReference section */
 		4027B774186205EC00168444 /* RCWHealthMeter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCWHealthMeter.h; sourceTree = "<group>"; };
 		4027B775186205EC00168444 /* RCWHealthMeter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCWHealthMeter.m; sourceTree = "<group>"; };
+		9E4A221A1BC5F2CB00AC5C3B /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AB006107183863EE00667A46 /* RCWGentleErrorNotificationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCWGentleErrorNotificationView.h; sourceTree = "<group>"; };
 		AB006108183863EE00667A46 /* RCWGentleErrorNotificationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCWGentleErrorNotificationView.m; sourceTree = "<group>"; };
 		AB021FEA183B1F4F00DC2725 /* RCWGentleErrorNotificationView-bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "RCWGentleErrorNotificationView-bg.png"; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				4027B775186205EC00168444 /* RCWHealthMeter.m */,
 				AB6B487318DE387300CBD711 /* RCWWebView.h */,
 				AB6B487418DE387300CBD711 /* RCWWebView.m */,
+				9E4A221A1BC5F2CB00AC5C3B /* LaunchScreen.storyboard */,
 				AB021FF3183B20B100DC2725 /* Client Protocol */,
 				AB14CA1A180E08A4000FCF87 /* Images.xcassets */,
 				AB14CA0F180E08A4000FCF87 /* Supporting Files */,
@@ -324,6 +327,7 @@
 				AB021FEB183B1F4F00DC2725 /* RCWGentleErrorNotificationView-bg.png in Resources */,
 				AB20479A1839C97400966A9D /* RCWGentleErrorNotificationView.xib in Resources */,
 				AB14CA13180E08A4000FCF87 /* InfoPlist.strings in Resources */,
+				9E4A221B1BC5F2CB00AC5C3B /* LaunchScreen.storyboard in Resources */,
 				AB14CA62180E0DD7000FCF87 /* Storyboard_iPhone.storyboard in Resources */,
 				AB14CA1B180E08A4000FCF87 /* Images.xcassets in Resources */,
 			);

--- a/client/KeyGrip/KeyGrip-Info.plist
+++ b/client/KeyGrip/KeyGrip-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Storyboard_iPhone</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/client/KeyGrip/LaunchScreen.storyboard
+++ b/client/KeyGrip/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
I updated the iOS client by simply adding a launch screen storyboard.  Without that in XCode7 you get black horizontal bars on the top/bottoms of the screen.   