### PR TITLE
Updating URL to resolve alias file://file./id=123.456

### DIFF
--- a/server/KeyGripServer/RCWKeyGripView.m
+++ b/server/KeyGripServer/RCWKeyGripView.m
@@ -91,7 +91,7 @@
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
     if ([[pboard types] containsObject:NSURLPboardType]) {
-        NSURL *draggedFile = [NSURL URLFromPasteboard:pboard];
+        NSURL *draggedFile = [NSURL URLFromPasteboard:pboard].filePathURL;
         if ([self.extensions containsObject:[draggedFile.pathExtension lowercaseString]]) {
             RCWAppDelegate *delegate = (RCWAppDelegate *)[NSApplication sharedApplication].delegate;
             [delegate handleDroppedFile:draggedFile];


### PR DESCRIPTION
At some point, URLFromPasteboard started returning file aliases instead
of direct paths.  Getting the property filePathURL from the URL
returned from the Pasteboard is now necessary.